### PR TITLE
Fixed bug where some users were not being included in the volunteers list

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -101,6 +101,9 @@ If the recurring opportunity will have the same volunteers each time, we’d rec
 
 == Changelog ==
 
+= 1.0.2 =
+* Fixed bug where some users were not being included in the volunteers list view when they should be.
+
 = 1.0.1 =
 * Fixed issue where template override directory was changed to match text domain.
 

--- a/includes/class-wi-volunteer-management.php
+++ b/includes/class-wi-volunteer-management.php
@@ -69,7 +69,7 @@ class WI_Volunteer_Management {
 	public function __construct() {
 
 		$this->plugin_name = 'wired-impact-volunteer-management';
-		$this->version = '1.0.1';
+		$this->version = '1.0.2';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/includes/class-wp-volunteer-list-table.php
+++ b/includes/class-wp-volunteer-list-table.php
@@ -58,19 +58,30 @@ class WI_Volunteer_Users_List_Table extends WP_Users_List_Table {
 
 		$usersearch = isset( $_REQUEST['s'] ) ? wp_unslash( trim( $_REQUEST['s'] ) ) : '';
 
-		$role = 'volunteer';
-
 		$per_page = 'users_per_page';
 		$users_per_page = $this->get_items_per_page( $per_page );
 
 		$paged = $this->get_pagenum();
 
+		//Get the IDs of all users who have RSVPed for a volunteer opportunity
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'volunteer_rsvps';
+		$query = "
+				SELECT DISTINCT user_id
+				FROM $table_name
+				";
+		$results = $wpdb->get_results( $query );
+		$volunteer_ids = array();
+		foreach( $results as $result ){
+			$volunteer_ids[] = $result->user_id;
+		}
+
 		$args = array(
-			'number' => $users_per_page,
-			'offset' => ( $paged-1 ) * $users_per_page,
-			'role' => $role,
-			'search' => $usersearch,
-			'fields' => 'all_with_meta'
+			'number' 	=> $users_per_page,
+			'offset' 	=> ( $paged-1 ) * $users_per_page,
+			'include'	=> $volunteer_ids,
+			'search' 	=> $usersearch,
+			'fields' 	=> 'all_with_meta'
 		);
 
 		if ( '' !== $args['search'] )

--- a/wivm.php
+++ b/wivm.php
@@ -17,7 +17,7 @@
  * Plugin Name:       Wired Impact Volunteer Management
  * Plugin URI:        http://wiredimpact.com/services-and-pricing/apps-for-nonprofits/volunteer-management/
  * Description:       A simple, free way to keep track of your nonprofit’s volunteers and opportunities.
- * Version:           1.0.1
+ * Version:           1.0.2
  * Author:            Wired Impact
  * Author URI:        http://wiredimpact.com
  * License:           GPL-2.0+


### PR DESCRIPTION
Fixed bug where some users were not being included in the volunteers list when they should be. This was due to the fact that we were only pulling users of the "volunteer" role when we should have pulled all users who have signed up for an opportunity at any time. Now we pull a list of user IDs from the RSVPs table to populate the list of volunteers.
