### PR TITLE
Renamed success class

### DIFF
--- a/frontend/css/wi-volunteer-management-public.css
+++ b/frontend/css/wi-volunteer-management-public.css
@@ -74,7 +74,7 @@
 	color: #990000;
 }
 
-.volunteer-opp-message.success {
+.volunteer-opp-message.rsvp-success {
 	color: #21732a;
 }
 

--- a/frontend/js/wi-volunteer-management-public.js
+++ b/frontend/js/wi-volunteer-management-public.js
@@ -47,7 +47,7 @@
 
 		//If not valid return false.
         if( has_errors === true ){
-        	$( '.volunteer-opp-message.loading, .volunteer-opp-message.success' ).slideUp();
+        	$( '.volunteer-opp-message.loading, .volunteer-opp-message.rsvp-success' ).slideUp();
         	$( '.volunteer-opp-message.error' ).slideDown();
         	return false;
         }
@@ -59,7 +59,7 @@
 
 	/**
 	 * Validates a provided email address.
-	 * 
+	 *
 	 * @param  {string} email The provided email address.
 	 * @return {bool}   	  Whether the provided email address is valid.
 	 */
@@ -90,10 +90,10 @@
 			function( response ){
 
 				$( '.volunteer-opp-message.loading' ).slideUp();
-				
+
 				//If submitter was RSVPed successfully
 				if( response === 'rsvped' ){
-					$( '.volunteer-opp-message.success' ).slideDown();
+					$( '.volunteer-opp-message.rsvp-success' ).slideDown();
 					submit_button.prop( "disabled", false );
 					track_google_analytics( 'RSVP Success' );
 				}

--- a/templates/opp-single-form.php
+++ b/templates/opp-single-form.php
@@ -9,10 +9,10 @@ $opp = new WI_Volunteer_Management_Opportunity( $post->ID ); //Get volunteer opp
 ?>
 
 <h3><?php ( $opp->opp_meta['one_time_opp'] == 1 ) ? _e( 'Sign Up to Volunteer', 'wired-impact-volunteer-management' ) : _e( 'Express Interest in Volunteering', 'wired-impact-volunteer-management' ) ; ?></h3>
-					
+
 <?php if( $opp->should_allow_rvsps() ): ?>
 <div class="loading volunteer-opp-message"><?php _e( 'Please wait...', 'wired-impact-volunteer-management' ); ?></div>
-<div class="success volunteer-opp-message"><?php _e( 'Thanks for signing up. You\'ll receive a confirmation email shortly.', 'wired-impact-volunteer-management' ); ?></div>
+<div class="rsvp-success volunteer-opp-message"><?php _e( 'Thanks for signing up. You\'ll receive a confirmation email shortly.', 'wired-impact-volunteer-management' ); ?></div>
 <div class="already-rsvped volunteer-opp-message"><?php _e( 'It looks like you already signed up for this opportunity.', 'wired-impact-volunteer-management' ); ?></div>
 <div class="rsvp-closed volunteer-opp-message"><?php _e( 'We\'re sorry, but we weren\'t able to sign you up. We have no more open spots.', 'wired-impact-volunteer-management' ); ?></div>
 <div class="error volunteer-opp-message"><?php _e( 'Please fill in every field and make sure you entered a valid email address.', 'wired-impact-volunteer-management' ); ?></div>

--- a/wivm.php
+++ b/wivm.php
@@ -17,7 +17,7 @@
  * Plugin Name:       Wired Impact Volunteer Management
  * Plugin URI:        http://wiredimpact.com/services-and-pricing/apps-for-nonprofits/volunteer-management/
  * Description:       A simple, free way to keep track of your nonprofit’s volunteers and opportunities.
- * Version:           1.0.2
+ * Version:           1.0.3
  * Author:            Wired Impact
  * Author URI:        http://wiredimpact.com
  * License:           GPL-2.0+


### PR DESCRIPTION
This corrects a problem with themes that already contain a .success CSS class with a `display: block` property:

```
.success {
   display: block;
   ...
}
```

Upon initial navigation to the RSVP page, the RSVP message is already visible. This fix will modify the class name to `.rsvp-success` to avoid conflicts. 
