### PR TITLE
Adjusted plugin permissions for clearer and easier editing for different roles

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -183,11 +183,14 @@ class WI_Volunteer_Management_Admin {
 	}
 
 	/**
-	 * Register our menu and its sub menu's.
+	 * Register our menu and its sub menu pages.
+	 *
+	 * We also use this to make other menu changes such as changing the first submenu item name
+	 * and hiding the top level Volunteer Mgmt menu from roles without permission to use it.
 	 *
 	 * @global array $submenu used to change the label on the first item.
 	 */
-	public function register_settings_page() {
+	public function do_menu_changes() {
 
 		// Base 64 encoded SVG image
 		$icon_svg = 'dashicons-groups';
@@ -196,7 +199,7 @@ class WI_Volunteer_Management_Admin {
 		$admin_page = add_menu_page(
 			__( 'Wired Impact Volunteer Management: ', 'wired-impact-volunteer-management' ) . ' ' . __( 'Help & Settings', 'wired-impact-volunteer-management' ),
 			__( 'Volunteer Mgmt', 'wired-impact-volunteer-management' ),
-			'manage_options',
+			'edit_others_posts',
 			'wi-volunteer-management',
 			array( $this, 'load_page' ),
 			$icon_svg,
@@ -209,7 +212,7 @@ class WI_Volunteer_Management_Admin {
 				'wi-volunteer-management',
 				'',
 				__( 'Volunteers', 'wired-impact-volunteer-management' ),
-				'manage_options',
+				'edit_others_posts',
 				'wi-volunteer-management-volunteers',
 				array( $this, 'load_page' ),
 			),
@@ -217,7 +220,7 @@ class WI_Volunteer_Management_Admin {
 				'wi-volunteer-management',
 				'',
 				__( 'Help & Settings', 'wired-impact-volunteer-management' ),
-				'manage_options',
+				'edit_others_posts',
 				'wi-volunteer-management-help-settings',
 				array( $this, 'load_page' ),
 			),
@@ -225,7 +228,7 @@ class WI_Volunteer_Management_Admin {
 				NULL, //Not in menu
 				'',
 				__( 'Volunteer', 'wired-impact-volunteer-management' ),
-				'manage_options',
+				'edit_others_posts',
 				'wi-volunteer-management-volunteer',
 				array( $this, 'load_page' ),
 			),
@@ -244,8 +247,13 @@ class WI_Volunteer_Management_Admin {
 
 		//Change the submenu name for the 1st item
 		global $submenu;
-		if ( isset( $submenu['wi-volunteer-management'] ) && current_user_can( 'manage_options' ) ) {
+		if ( isset( $submenu['wi-volunteer-management'] ) && current_user_can( 'edit_others_posts' ) ) {
 			$submenu['wi-volunteer-management'][0][0] = __( 'Opportunities', 'wired-impact-volunteer-management' );
+		}
+
+		//Hide the Volunteer Mgmt menu from anyone without edit_others_posts permission
+		if( !current_user_can( 'edit_others_posts' ) ){
+			remove_menu_page( 'wi-volunteer-management' );
 		}
 	}
 
@@ -1061,7 +1069,7 @@ class WI_Volunteer_Management_Admin {
 		if( $post->post_type != 'volunteer_opp' ){
 		  return false;
 		}
-		if( !current_user_can( 'manage_options' ) ){
+		if( !current_user_can( 'edit_others_posts' ) ){
 		  return false;
 		}
 

--- a/admin/pages/help-settings.php
+++ b/admin/pages/help-settings.php
@@ -21,9 +21,11 @@ $wi_form->admin_header();
 	
 	<h2 class="nav-tab-wrapper" id="wivm-tabs">
 		<a class="nav-tab" id="help-tab" href="#top#help"><span class="dashicons dashicons-editor-help"></span> <?php _e( 'Help', 'wired-impact-volunteer-management' ); ?></a>
+		<?php if( current_user_can( 'manage_options' ) ): ?>
 		<a class="nav-tab" id="general-tab" href="#top#general"><span class="dashicons dashicons-admin-tools"></span> <?php _e( 'General', 'wired-impact-volunteer-management' ); ?></a>
 		<a class="nav-tab" id="defaults-tab" href="#top#defaults"><span class="dashicons dashicons-admin-generic"></span> <?php _e( 'Opportunity Defaults', 'wired-impact-volunteer-management' ); ?></a>
 		<a class="nav-tab" id="email-tab" href="#top#email"><span class="dashicons dashicons-email-alt"></span> <?php _e( 'Email', 'wired-impact-volunteer-management' ); ?></a>
+		<?php endif; ?>
 	</h2>
 
 	<?php
@@ -44,6 +46,7 @@ $wi_form->admin_header();
 	$wi_form->form_table_end();
 
 	//Display General settings tab
+	if( current_user_can( 'manage_options' ) ):
 	$wi_form->form_table_start( 'general' );
 
 		$wi_form->radio( 'use_css', array( 1 => __( 'Yes, please provide basic styling.', 'wired-impact-volunteer-management' ), 0 => __( 'No, I\'ll code my own styling.', 'wired-impact-volunteer-management' ) ), 'Load Plugin CSS?' );
@@ -89,5 +92,6 @@ $wi_form->admin_header();
     	do_action( 'wivm_display_email_settings', $wi_form );
 
 	$wi_form->form_table_end();
+	endif;
 
 $wi_form->admin_footer();

--- a/admin/pages/volunteer.php
+++ b/admin/pages/volunteer.php
@@ -12,7 +12,7 @@
  * @subpackage WI_Volunteer_Management/Admin
  */
 
-if ( !current_user_can( 'list_users' ) || !isset( $_REQUEST['user_id'] ) ){
+if ( !current_user_can( 'edit_others_posts' ) || !isset( $_REQUEST['user_id'] ) ){
 	wp_die( __( 'Cheatin&#8217; uh?', 'wired-impact-volunteer-management' ), 403 );
 }
 
@@ -45,9 +45,11 @@ $volunteer = new WI_Volunteer_Management_Volunteer( $volunteer_id );
 		</div>
 
 		<div class="contact-footer clear">
+			<?php if( current_user_can( 'edit_users' ) ): ?>
 			<a href="<?php echo admin_url( 'user-edit.php?user_id=' . $volunteer_id ); ?>" class="button edit-volunteer">
 				<?php _e( 'Edit Volunteer Info', 'wired-impact-volunteer-management' ); ?>
 			</a>
+			<?php endif; ?>
 		</div>
 	
 	</div><!-- .volunteer-info -->

--- a/admin/pages/volunteers.php
+++ b/admin/pages/volunteers.php
@@ -12,7 +12,7 @@
  * @subpackage WI_Volunteer_Management/Admin
  */
 
-if ( !current_user_can( 'list_users' ) ){
+if ( !current_user_can( 'edit_others_posts' ) ){
 	wp_die( __( 'Cheatin&#8217; uh?', 'wired-impact-volunteer-management' ), 403 );
 }
 

--- a/includes/class-wi-volunteer-management.php
+++ b/includes/class-wi-volunteer-management.php
@@ -194,7 +194,7 @@ class WI_Volunteer_Management {
 		$this->loader->add_action(   'plugins_loaded',                             $plugin_admin, 'do_upgrades' );
 		$this->loader->add_action(   'admin_enqueue_scripts',                      $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action(   'admin_enqueue_scripts',                      $plugin_admin, 'enqueue_scripts' );
-		$this->loader->add_action(   'admin_menu',                                 $plugin_admin, 'register_settings_page' );
+		$this->loader->add_action(   'admin_menu',                                 $plugin_admin, 'do_menu_changes' );
 		$this->loader->add_action(   'admin_init',                                 $plugin_admin, 'register_settings' );
 		$this->loader->add_action(   'edit_form_after_editor',                     $plugin_admin, 'show_opp_editor_description' );
 		$this->loader->add_action(   'add_meta_boxes',                             $plugin_admin, 'add_meta_boxes' );


### PR DESCRIPTION
- Adjusted permissions so editors also have access to publish, edit and otherwise view anything related to volunteer management.
- Hid Volunteer Mgmt menu for anyone less than the Editor role.
- Adjusted the Help & Settings page so editors could view the help information, but not the settings.
- Removed the "Edit Volunteer Info" button for editors when viewing individual volunteers since they don't have access to change user settings.
