### PR TITLE
Revision - Pass useful arguments for custom attributes

### DIFF
--- a/includes/class-email.php
+++ b/includes/class-email.php
@@ -272,7 +272,7 @@ class WI_Volunteer_Management_Email {
 				'{contact_email}'           => $this->opp->opp_meta['contact_email'],
 			);
 
-			$search_and_replace_text  = apply_filters( 'wivm_search_and_replace_text', $search_and_replace_text );
+			$search_and_replace_text  = apply_filters( 'wivm_search_and_replace_text', $search_and_replace_text, $this->user->ID );
 
 			foreach( $search_and_replace_text as $key => $value ){
 				$this->search_text[]  = $key;

--- a/includes/class-email.php
+++ b/includes/class-email.php
@@ -272,7 +272,10 @@ class WI_Volunteer_Management_Email {
 				'{contact_email}'           => $this->opp->opp_meta['contact_email'],
 			);
 
-			$search_and_replace_text  = apply_filters( 'wivm_search_and_replace_text', $search_and_replace_text, $this->user->ID );
+
+			//Set up user object to pass into filter, false if does not exist
+			$user = $this->user ? $this->user : false;
+			$search_and_replace_text  = apply_filters( 'wivm_search_and_replace_text', $search_and_replace_text, $user );
 
 			foreach( $search_and_replace_text as $key => $value ){
 				$this->search_text[]  = $key;

--- a/includes/class-volunteer.php
+++ b/includes/class-volunteer.php
@@ -291,7 +291,7 @@ class WI_Volunteer_Management_Volunteer {
 
 		$this->ID = $user_id;
 
-		do_action( 'wivm_create_update_user', $this->ID );
+		do_action( 'wivm_create_update_user', $this->ID, $form_fields );
 	}
 
 	/**


### PR DESCRIPTION
- Grabbing the functionality changes from PR #3

Adds the `$form_fields` parameter to the `wivm_create_update_user` action, allowing for the ability to add custom field values to the user meta data.

Adds the user ID to the `wivm_search_and_replace_text` filter, allowing for the ability to query custom user metadata and add these fields as replacement tokens.
