### PR TITLE
Initial implementation of honeypot spam prevention

### DIFF
--- a/admin/pages/help-settings.php
+++ b/admin/pages/help-settings.php
@@ -50,6 +50,7 @@ $wi_form->admin_header();
 	$wi_form->form_table_start( 'general' );
 
 		$wi_form->radio( 'use_css', array( 1 => __( 'Yes, please provide basic styling.', 'wired-impact-volunteer-management' ), 0 => __( 'No, I\'ll code my own styling.', 'wired-impact-volunteer-management' ) ), 'Load Plugin CSS?' );
+		$wi_form->radio( 'use_honeypot', array( 1 => __( 'Yes, please use a honeypot to prevent spam.', 'wired-impact-volunteer-management' ), 0 => __( 'No, I\'ll handle spam in my own way.', 'wired-impact-volunteer-management' ) ), 'Enable Honeypot?' );
 		$wi_form->hidden( 'show_getting_started_notice' );
 
 		do_action( 'wivm_display_general_settings', $wi_form );

--- a/frontend/class-public.php
+++ b/frontend/class-public.php
@@ -314,6 +314,12 @@ class WI_Volunteer_Management_Public {
 			die();
 		}
 
+		//If the honeypot field exists and is filled out then bail 
+		if( isset( $form_fields['wivm_hp'] ) && $form_fields['wivm_hp'] != '' ){
+			_e( 'Security Check.', 'wired-impact-volunteer-management' );
+			die();
+		}
+
 		$opp = new WI_Volunteer_Management_Opportunity( $form_fields['wivm_opportunity_id'] );
 		if( $opp->should_allow_rvsps() == true ){
 

--- a/frontend/class-public.php
+++ b/frontend/class-public.php
@@ -71,6 +71,29 @@ class WI_Volunteer_Management_Public {
 	}
 
 	/**
+	 * Hide the honeypot field for the volunteer sign up form.
+	 *
+	 * We load this CSS separately to be sure the field is hidden even if the 
+	 * admin has turned off loading the CSS within the settings.
+	 */
+	public function enqueue_honeypot_styles(){
+
+		if( is_singular( 'volunteer_opp' ) ): ?>
+		
+		<style>
+			/* Hide the Wired Impact Volunteer Management honeypot field under all circumstances */
+			.wivm_hp { 
+				display: none !important;
+			    position: absolute !important;
+			    left: -9000px;
+			}
+		</style>
+
+		<?php endif;
+
+	}
+
+	/**
 	 * Register the stylesheets for the public-facing side of the site.
 	 *
 	 * @since    0.1

--- a/frontend/css/wi-volunteer-management-public.css
+++ b/frontend/css/wi-volunteer-management-public.css
@@ -62,12 +62,6 @@
 	float: right;
 }
 
-.wivm_hp { /* Hide our honeypot field under all circumstances */
-	display: none !important;
-    position: absolute !important;
-    left: -9000px;
-}
-
 .volunteer-opp-message {
 	display: none;
 	font-size: .9em;

--- a/frontend/css/wi-volunteer-management-public.css
+++ b/frontend/css/wi-volunteer-management-public.css
@@ -62,6 +62,12 @@
 	float: right;
 }
 
+.wivm_hp { /* Hide our honeypot field under all circumstances */
+	display: none !important;
+    position: absolute !important;
+    left: -9000px;
+}
+
 .volunteer-opp-message {
 	display: none;
 	font-size: .9em;

--- a/frontend/js/wi-volunteer-management-public.js
+++ b/frontend/js/wi-volunteer-management-public.js
@@ -31,7 +31,15 @@
 	 */
 	function validate_sign_up_form(){
 		var has_errors = false;
-		$( '#wivm-sign-up-form input[type=text], #wivm-sign-up-form input[type=email]' ).each(function() {
+
+		//Show an error and don't submit if the honeypot exists and is filled in
+		var hp = $( '#wivm_hp' );
+		if( hp.length && hp.val() !== '' ){
+			has_errors = true;
+		}
+
+		//Make sure each field is filled in and that email addresses are valid
+		$( '#wivm-sign-up-form input[type=text]:not(#wivm_hp), #wivm-sign-up-form input[type=email]' ).each(function() {
             if( this.value === '' ) {
                 $( this ).addClass( 'field-error' );
                 has_errors = true;

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -40,6 +40,7 @@ class WI_Volunteer_Management_Options {
 	public $defaults = array(
 		//General
 		'use_css'              				=> 1,
+		'use_honeypot'						=> 1,
 		'show_getting_started_notice'		=> 1,
 
 		//Defaults

--- a/includes/class-wi-volunteer-management.php
+++ b/includes/class-wi-volunteer-management.php
@@ -236,6 +236,7 @@ class WI_Volunteer_Management {
       $plugin_widget = new WI_Volunteer_Management_Widget( $this->get_plugin_name(), $this->get_version() );
 
 		$this->loader->add_action(      'wp_enqueue_scripts',            $plugin_public, 'enqueue_styles' );
+		$this->loader->add_action(      'wp_head',            			 $plugin_public, 'enqueue_honeypot_styles' );
 		$this->loader->add_action(      'wp_enqueue_scripts',            $plugin_public, 'enqueue_scripts' );
 		$this->loader->add_action(      'init',                          $plugin_public, 'register_post_types' );
 		$this->loader->add_shortcode(   'one_time_volunteer_opps',       $plugin_public, 'display_one_time_volunteer_opps' );

--- a/templates/opp-single-form.php
+++ b/templates/opp-single-form.php
@@ -4,8 +4,14 @@
  *
  * This template is displayed immediately after the_content() is called within your theme file.
  * To adjust this template copy it into your current theme within a folder called "wivm".
+ *
+ * Please note that the field called "wivm_hp" is a honeypot field used for spam protection. It is
+ * hidden via CSS when the form is displayed. Only spambots can see this and when they fill it out
+ * the form won't submit. You can turn on or off the honeypot within the plugin settings.
  */
 $opp = new WI_Volunteer_Management_Opportunity( $post->ID ); //Get volunteer opportunity information
+$options = new WI_Volunteer_Management_Options();
+$use_honeypot = $options->get_option( 'use_honeypot' );
 ?>
 
 <h3><?php ( $opp->opp_meta['one_time_opp'] == 1 ) ? _e( 'Sign Up to Volunteer', 'wired-impact-volunteer-management' ) : _e( 'Express Interest in Volunteering', 'wired-impact-volunteer-management' ) ; ?></h3>
@@ -34,10 +40,15 @@ $opp = new WI_Volunteer_Management_Opportunity( $post->ID ); //Get volunteer opp
 	<label for="wivm_email"><?php _e( 'Email:', 'wired-impact-volunteer-management' ); ?></label>
 	<input type="email" tabindex="930" id="wivm_email" name="wivm_email" value="" />
 
+	<?php if( $use_honeypot == 1 ): ?>
+	<label for="wivm_hp" class="wivm_hp"><?php _e( 'Name:', 'wired-impact-volunteer-management' ); ?></label>
+	<input type="text" tabindex="940" class="wivm_hp" id="wivm_hp" name="wivm_hp" value=""  autocomplete="off" />
+	<?php endif; ?>
+
 	<?php do_action( 'wivm_end_sign_up_form_fields', $post ); ?>
 
 	<input type="hidden" id="wivm_opportunity_id" name="wivm_opportunity_id" value="<?php echo the_ID(); ?>" />
-	<input type="submit" tabindex="940" value="<?php ( $opp->opp_meta['one_time_opp'] == 1 ) ? _e( 'Sign Up', 'wired-impact-volunteer-management' ) : _e( 'Express Interest', 'wired-impact-volunteer-management' ) ; ?>" />
+	<input type="submit" tabindex="950" value="<?php ( $opp->opp_meta['one_time_opp'] == 1 ) ? _e( 'Sign Up', 'wired-impact-volunteer-management' ) : _e( 'Express Interest', 'wired-impact-volunteer-management' ) ; ?>" />
 </form>
 <?php else: ?>
 	<p><?php _e( 'We\'re sorry, but we\'re no longer accepting new volunteers for this opportunity.', 'wired-impact-volunteer-management' ); ?></p>


### PR DESCRIPTION
This adds an additional honeypot field to the volunteer sign up form to prevent spam submissions. The field is hidden using CSS and if it's filled out javascript won't allow the form to be submitted. If for whatever reason the javascript is disabled, there is PHP that also checks to see if the honeypot field is filled out. If so, it also won't process the sign up.

I've also added an option within the plugin that allows you to turn on or off the honeypot. That way if the admin has any issues with it at all they can simply turn it off. One example case where you might want to turn it off is if you're using custom CSS styling for the plugin and don't want to have to write new CSS to hide that field. Instead, you can simply turn it off.

I'm excited for you to take a look.