### PR TITLE
Fix issue where volunteers don't appear on the Volunteers page and where multisite subsites aren't activated correctly

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: wiredimpact
 Tags: nonprofits, non profits, not-for-profit, volunteers, volunteer
 Requires at least: 4.0
 Tested up to: 4.8
-Stable tag: 1.3.1
+Stable tag: 1.3.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -100,6 +100,10 @@ If the recurring opportunity will have the same volunteers each time, we’d rec
 1. View Volunteer Profiles
 
 == Changelog ==
+
+= 1.3.3 =
+* Fixed multisite bug where volunteers weren't displaying on the Volunteers page if they had already signed up through another subsite.
+* Fixed multisite bug where volunteer opportunity URLs were broken if the plugin had been network-activated.
 
 = 1.3.2 =
 * Tested up to WordPress 4.8 and adjusted admin headings for improved accessibility. 

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -23,16 +23,42 @@
 class WI_Volunteer_Management_Activator {
 
 	/**
-	 * On activation flush rewrite rules.
+	 * Run the necessary activation process for all sites or the current one.
 	 *
-	 * On activation we first declare our custom post type and then
-	 * flush rewrite rules so our custom url structure works how we'd want it to.
-	 * Along with that we create our volunteer role to be used to easily track volunteers
-	 * who sign up for volunteer opportunities on the website.
+	 * If we're working with a multisite installation and the plugin is being
+	 * turned on network-wide then run the activation on all sites in the network.
+	 * If not, run the activation only on the current site.
 	 *
 	 * @since    0.1
+	 * @param 	 $network_wide Whether the plugin is being network enabled on multisite
 	 */
-	public static function activate() {
+	public static function activate( $network_wide = false ) {
+		// If multisite and network activated run our activation on all sites
+		if ( is_multisite() && $network_wide ) { 
+			global $wpdb;
+			$blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+			foreach( $blog_ids as $blog_id ) {
+				switch_to_blog( $blog_id );
+				WI_Volunteer_Management_Activator::activate_site();
+				restore_current_blog();
+			} 
+	    }
+	    else {
+	        WI_Volunteer_Management_Activator::activate_site();
+	    }
+	}
+
+	/**
+	 * On activation flush rewrite rules, add the volunteer role and set defaults.
+	 *
+	 * On activation we first declare our custom post type and then flush rewrite rules
+	 * so our custom url structure works how we'd want it to. Along with that we create
+	 * our volunteer role to be used to easily track volunteers who sign up for volunteer
+	 * opportunities on the website. Finally, we add our default options to the database.
+	 *
+	 * @since    1.3.3
+	 */
+	public static function activate_site(){
 		WI_Volunteer_Management_Public::register_post_types();
 		flush_rewrite_rules();
 

--- a/includes/class-volunteer.php
+++ b/includes/class-volunteer.php
@@ -289,6 +289,11 @@ class WI_Volunteer_Management_Volunteer {
 			$userdata['ID'] = $existing_user;
 
 			$user_id = wp_update_user( $userdata );
+
+			//On multisite we need to add the user to this site if they don't have access
+			if( is_multisite() && !is_user_member_of_blog( $userdata['ID'] ) ){
+				add_user_to_blog( get_current_blog_id(), $userdata['ID'], 'volunteer' );
+			}
 		}
 
 		//Update custom user meta for new and existing volunteers.

--- a/includes/class-wi-volunteer-management.php
+++ b/includes/class-wi-volunteer-management.php
@@ -69,7 +69,7 @@ class WI_Volunteer_Management {
 	public function __construct() {
 
 		$this->plugin_name = 'wired-impact-volunteer-management';
-		$this->version = '1.3.2';
+		$this->version = '1.3.3';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/wivm.php
+++ b/wivm.php
@@ -17,7 +17,7 @@
  * Plugin Name:       Wired Impact Volunteer Management
  * Plugin URI:        http://wiredimpact.com/services-and-pricing/apps-for-nonprofits/volunteer-management/
  * Description:       A simple, free way to keep track of your nonprofit’s volunteers and opportunities.
- * Version:           1.3.2
+ * Version:           1.3.3
  * Author:            Wired Impact
  * Author URI:        http://wiredimpact.com
  * License:           GPL-2.0+
@@ -52,6 +52,8 @@ register_activation_hook( __FILE__, 'activate_wi_volunteer_management' );
  * already activated network-wide. In this case we need to run 
  * the activation method since the plugin will never be enabled
  * through the admin.
+ *
+ * @since  1.3.3
  */
 function multisite_activate_wi_volunteer_management( $blog_id ){
 	if ( is_plugin_active_for_network( plugin_basename( __FILE__ ) ) ) {

--- a/wivm.php
+++ b/wivm.php
@@ -34,13 +34,35 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-activator.php
+ *
+ * @param $network_wide Whether the plugin is being network enabled on multisite
  */
-function activate_wi_volunteer_management() {
+function activate_wi_volunteer_management( $network_wide = false ) {
 	require_once WIVM_DIR . 'includes/class-activator.php';
-	WI_Volunteer_Management_Activator::activate();
+	WI_Volunteer_Management_Activator::activate( $network_wide );
 }
 
 register_activation_hook( __FILE__, 'activate_wi_volunteer_management' );
+
+/**
+ * Run the activation when a new multisite blog is created.
+ *
+ * This function is different than the general activation since it
+ * only runs on the given subsite and only if the plugin is 
+ * already activated network-wide. In this case we need to run 
+ * the activation method since the plugin will never be enabled
+ * through the admin.
+ */
+function multisite_activate_wi_volunteer_management( $blog_id ){
+	if ( is_plugin_active_for_network( plugin_basename( __FILE__ ) ) ) {
+		switch_to_blog( $blog_id );
+		require_once WIVM_DIR . 'includes/class-activator.php';
+		WI_Volunteer_Management_Activator::activate_site();
+		restore_current_blog();
+	}
+}
+
+add_action( 'wpmu_new_blog', 'multisite_activate_wi_volunteer_management' );
 
 /**
  *  Add constant to allow us to easily load files.


### PR DESCRIPTION
This pull request fixes two main problems:

1. On multisite volunteers were not showing in the Volunteers page list for a subsite if they had already signed up on another subsite.
2. If the plugin was network activated already each site wasn't going through the activation process when created. Given this, the permalinks were breaking in some cases and the volunteer role didn't exist on any new sites.