### PR TITLE
Tested up to WordPress 4.9 and fixed display of number of custom emails sent for opportunity

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,8 +2,8 @@
 Contributors: wiredimpact
 Tags: nonprofits, non profits, not-for-profit, volunteers, volunteer
 Requires at least: 4.0
-Tested up to: 4.8
-Stable tag: 1.3.5
+Tested up to: 4.9
+Stable tag: 1.3.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -100,6 +100,10 @@ If the recurring opportunity will have the same volunteers each time, we’d rec
 1. View Volunteer Profiles
 
 == Changelog ==
+
+= 1.3.6 =
+* Tested up to WordPress 4.9.
+* Fixed bug where the number of custom emails sent to volunteers for an opportunity might have displayed incorrectly.
 
 = 1.3.5 =
 * Fixed bug where translating "Volunteer Mgmt" would break the Help & Settings admin page.

--- a/includes/class-opportunity.php
+++ b/includes/class-opportunity.php
@@ -348,7 +348,7 @@ class WI_Volunteer_Management_Opportunity {
 		         ORDER BY time DESC
 		        ";
 
-		$query_values = array( $this->ID, 1 );
+		$query_values = $this->ID;
 
 		return $wpdb->get_results( $wpdb->prepare( $query, $query_values ) );
 	}

--- a/includes/class-wi-volunteer-management.php
+++ b/includes/class-wi-volunteer-management.php
@@ -69,7 +69,7 @@ class WI_Volunteer_Management {
 	public function __construct() {
 
 		$this->plugin_name = 'wired-impact-volunteer-management';
-		$this->version = '1.3.5';
+		$this->version = '1.3.6';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/wivm.php
+++ b/wivm.php
@@ -17,7 +17,7 @@
  * Plugin Name:       Wired Impact Volunteer Management
  * Plugin URI:        https://wiredimpact.com/wordpress-plugins-for-nonprofits/volunteer-management/
  * Description:       A simple, free way to keep track of your nonprofit’s volunteers and opportunities.
- * Version:           1.3.5
+ * Version:           1.3.6
  * Author:            Wired Impact
  * Author URI:        https://wiredimpact.com
  * License:           GPL-2.0+


### PR DESCRIPTION
* Tested up to WordPress 4.9.
* Fixed bug where the number of custom emails sent to volunteers for an
opportunity might have displayed incorrectly.